### PR TITLE
Update junction-python to 0.3.0

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -31,7 +31,7 @@ client = junction.default_client()
 Then some options:
 
 ```python
-client.resolve_http("GET", "http://wineinfo-search.default.svc.cluster.local/search/?foo=bar", {})
+client.resolve_http(http://wineinfo-search.default.svc.cluster.local/search/?foo=bar")
 client.dump_routes()
 client.dump_backends()
 ```

--- a/demo/02_routing.md
+++ b/demo/02_routing.md
@@ -209,9 +209,7 @@ will get routed to.
 ```python
 (route, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(catalog) + "/",
-    headers={},
 )
 assert rule_idx == len(route["rules"]) - 1
 assert backend == { **catalog, "port": 80 }
@@ -228,7 +226,6 @@ This double-checks that:
 ```python
 (route, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(catalog) + "/",
     headers={"baggage": "username=admin"},
 )

--- a/demo/03_retries.md
+++ b/demo/03_retries.md
@@ -94,9 +94,7 @@ lets show that the path matching works, even when we specify a query string:
 ```python
 (matched, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(search) + RemoteSearchService.SEARCH + "?term=foo",
-    headers={},
 )
 rule = matched["rules"][rule_idx]
 assert rule["timeouts"]["backend_request"] == 0.1
@@ -108,9 +106,7 @@ Now let's show the fallback route is not getting retries or timeouts set:
 ```python
 (matched, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url=search_url + "/foo/",
-    headers={},
 )
 rule = matched["rules"][rule_idx]
 assert not "timeouts" in rule

--- a/demo/scripts/02_routing.py
+++ b/demo/scripts/02_routing.py
@@ -36,16 +36,13 @@ route: config.Route = {
 
 (route, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(catalog) + "/",
-    headers={},
 )
 assert rule_idx == len(route["rules"]) - 1
 assert backend == {**catalog, "port": 80}
 
 (route, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(catalog) + "/",
     headers={"baggage": "username=admin"},
 )

--- a/demo/scripts/03_retries.py
+++ b/demo/scripts/03_retries.py
@@ -41,9 +41,7 @@ route: config.Route = {
 
 (matched, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(search) + SEARCH_SERVICE["search"]["path"] + "?term=foo",
-    headers={},
 )
 rule = matched["rules"][rule_idx]
 assert rule["timeouts"]["backend_request"] == 0.1
@@ -52,9 +50,7 @@ assert rule["retry"]["attempts"] == 5
 
 (matched, rule_idx, backend) = junction.check_route(
     routes=[route],
-    method="GET",
     url="http://" + service_hostname(search) + "/foo/",
-    headers={},
 )
 rule = matched["rules"][rule_idx]
 assert not "timeouts" in rule

--- a/python_services/requirements.txt
+++ b/python_services/requirements.txt
@@ -3,5 +3,5 @@ pydantic-settings
 uvicorn
 whoosh
 chromadb
-junction-python>=0.2
+junction-python>=0.3
 yaspin


### PR DESCRIPTION
Updates us to `junction-python` 0.3.0.

The only api-facing changes here is that a bunch of the `method` and `headers` args become optional in demo code.