### PR TITLE
Upgrade to junction-python 0.3.3

### DIFF
--- a/demo/scripts/03_retries.py
+++ b/demo/scripts/03_retries.py
@@ -1,6 +1,6 @@
 import junction
 import junction.config as config
-from utils import kubectl_apply, service_fqdn
+from utils import kubectl_apply, service_fqdn, kube_search_config
 
 # just a little sys.path hack to import our Backend code without making this a
 # module. in the real world, we hope you don't have to do this!
@@ -42,6 +42,7 @@ route: config.Route = {
 (matched, rule_idx, backend) = junction.check_route(
     routes=[route],
     url="http://wineinfo-search" + SEARCH_SERVICE["search"]["path"] + "?term=foo",
+    search_config=kube_search_config(),
 )
 rule = matched["rules"][rule_idx]
 assert rule["timeouts"]["backend_request"] == 0.1
@@ -51,9 +52,10 @@ assert rule["retry"]["attempts"] == 5
 (matched, rule_idx, backend) = junction.check_route(
     routes=[route],
     url="http://wineinfo-search" + "/foo/",
+    search_config=kube_search_config(),
 )
 rule = matched["rules"][rule_idx]
-assert not "timeouts" in rule
-assert not "retry" in rule
+assert "timeouts" not in rule
+assert "retry" not in rule
 
 kubectl_apply(junction.dump_kube_route(route=route, namespace="default"))

--- a/demo/scripts/utils.py
+++ b/demo/scripts/utils.py
@@ -3,6 +3,21 @@ import subprocess
 import junction
 
 
+def kube_search_config(namespace="default"):
+    """
+    Returns a Junction search config that mirrors the /etc/resolv.conf
+    that Kubernetes puts in all Pods by default.
+    """
+    return {
+        "search": [
+            f"{namespace}.svc.cluster.local",
+            "svc.cluster.local",
+            "cluster.local",
+        ],
+        "ndots": 5,
+    }
+
+
 def service_fqdn(service: junction.config.Service) -> str:
     """
     Returns the fqdn for a junction Service, to be used in

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend3",
       "version": "0.1.0",
       "dependencies": {
-        "@junction-labs/client": "^0.3.1",
+        "@junction-labs/client": "^0.3.2",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.1.1",
         "class-variance-authority": "^0.7.1",
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/@junction-labs/client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client/-/client-0.3.1.tgz",
-      "integrity": "sha512-I9XMZIlW3DrPRyPqqaO2TDArai9qmLnrrc+Xuke30pfA6xdO0FyuTHOMVexzq9oDOX3XyFG4AQ9p1uE93B3thw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client/-/client-0.3.2.tgz",
+      "integrity": "sha512-phkBd+ZZg0RGvR8iF+6SqAFbb8r/wfYsclHQJhmywTJSgOZYCICRuDYXNh/xPp9RLhEZ+0+zECZF8g0HCfSFfQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -736,17 +736,17 @@
         "undici": "^7.2.0"
       },
       "optionalDependencies": {
-        "@junction-labs/client-darwin-arm64": "0.3.1",
-        "@junction-labs/client-darwin-x64": "0.3.1",
-        "@junction-labs/client-linux-arm64-gnu": "0.3.1",
-        "@junction-labs/client-linux-x64-gnu": "0.3.1",
-        "@junction-labs/client-win32-x64-msvc": "0.3.1"
+        "@junction-labs/client-darwin-arm64": "0.3.2",
+        "@junction-labs/client-darwin-x64": "0.3.2",
+        "@junction-labs/client-linux-arm64-gnu": "0.3.2",
+        "@junction-labs/client-linux-x64-gnu": "0.3.2",
+        "@junction-labs/client-win32-x64-msvc": "0.3.2"
       }
     },
     "node_modules/@junction-labs/client-darwin-arm64": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-arm64/-/client-darwin-arm64-0.3.1.tgz",
-      "integrity": "sha512-2Ae2cuomWdMSm/Sw6lKbp3EFqGrsg6wS4KEVJKWk5QcfF336lUM2onOAnX1z8WndXMUZYcMiZmYIeHQ2UlS8Uw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-arm64/-/client-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-ZqW+0QVx9Lpnjo4mQ4LY4EjpOKbeXaF5h/QBzhtu1uQVVmGnUhnmpX+4/k0dVbzTtrYgw4CPpb+RriBXwTBt0w==",
       "cpu": [
         "arm64"
       ],
@@ -757,9 +757,9 @@
       ]
     },
     "node_modules/@junction-labs/client-darwin-x64": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-x64/-/client-darwin-x64-0.3.1.tgz",
-      "integrity": "sha512-0iF8Qw6wdEQR7Z9+eJ+gvKTDdzLLomQZsuLe/trqfCNju47P1NrLZ0lP3xMqCRI7cp3sqkSRZV/cWpC0ieyuKg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-darwin-x64/-/client-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-kczyGG7DxCi3Tl0CL/G1Nm7ax+dBqrYJbDjtEShl6/tCticyzc9UVdiPNruwmSpokZVaAI/2zkZ8WJ6eKApaPg==",
       "cpu": [
         "x64"
       ],
@@ -770,9 +770,9 @@
       ]
     },
     "node_modules/@junction-labs/client-linux-arm64-gnu": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-arm64-gnu/-/client-linux-arm64-gnu-0.3.1.tgz",
-      "integrity": "sha512-yxaCMPPUIJYLtJYqerm/wrHUE6P0hVJkRWsZXeWKRUT4HiDuvvv7468h8+7+w7QwkD9CRfBWKn8S4KAr0U8hJA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-arm64-gnu/-/client-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-vNwSEif6FLhF0/K8lj2sMkcwvebMnZIn2LpM4HRpAE3wCaUyjGfWgrWoLHhIdZNQP45pJG16PvJsVU3efxfPPQ==",
       "cpu": [
         "arm64"
       ],
@@ -783,9 +783,9 @@
       ]
     },
     "node_modules/@junction-labs/client-linux-x64-gnu": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-x64-gnu/-/client-linux-x64-gnu-0.3.1.tgz",
-      "integrity": "sha512-pTVrIhUh0Aa9ZeuPN4dJ6h/ZEK+oShoCuvr/eRUMLxgtRMicqyTY2YZfeUbuVGsSY/5bI8hRwoNJ+CYDqmB3kg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-linux-x64-gnu/-/client-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-X63QHaylPGaZ7Q7eEq0gFjKLm+K4B2O9y8hO8G7LmeZv3EVMpnYOAX82oJ49yX95WBLkGO05KnR8sP8Q+eijYA==",
       "cpu": [
         "x64"
       ],
@@ -796,9 +796,9 @@
       ]
     },
     "node_modules/@junction-labs/client-win32-x64-msvc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@junction-labs/client-win32-x64-msvc/-/client-win32-x64-msvc-0.3.1.tgz",
-      "integrity": "sha512-KHi6S7BPncAnAeuAMbA/u6rgy+hqn0cXpqVxMdsInrAy3WpMPi1gGkywiJgISiLKdJ5KDNcB8pVWZsZUBrY2dQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@junction-labs/client-win32-x64-msvc/-/client-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-lHsX6xkwpIj0QLdCLx+ReqAAL/yoIRfnnHQmIsNbqdDbWpqt3yydB7OYaaPoI/Of/sJiBEpmfiTcxfQNdSVSzQ==",
       "cpu": [
         "x64"
       ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@junction-labs/client": ">=0.3.1",
+    "@junction-labs/client": "^0.3.2",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.1",

--- a/python_services/requirements.txt
+++ b/python_services/requirements.txt
@@ -3,5 +3,5 @@ pydantic-settings
 uvicorn
 whoosh
 chromadb
-junction-python>=0.3
+junction-python>=0.3.3
 yaspin


### PR DESCRIPTION
Upgrades to `junction-python` 0.3.3 so we can use `search_config` in `junction.check_route`. Also picks up [a bugfix](https://github.com/junction-labs/junction-client/pull/164) for a Pyo3 issue that was a causing internal client errors on slower machines.