### PR TITLE
feat: make wineinfo.sh more portable

### DIFF
--- a/deploy/wineinfo.sh
+++ b/deploy/wineinfo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set up a local k3d cluster with the wineinfo services running in the
 # default namespace and ezbake running in the junction namespace.


### PR DESCRIPTION
What does this PR do?
---

Different Linux distributions put bash in different places, some of them don't have it in `/bin/bash`. This will use `/usr/bin/env`, which is more likely to be there, as a workaround to run the first `bash` found on the `PATH`.