### PR TITLE
fix: use latest k3s rancher image

### DIFF
--- a/deploy/wineinfo.sh
+++ b/deploy/wineinfo.sh
@@ -30,7 +30,7 @@ k3d_cluster() {
     if k3d cluster list | grep -q "${cluster_name}"; then
         echo "cluster ${cluster_name} exists"
     else
-        k3d cluster create "$cluster_name" -p "8010-8011:30010-30011@loadbalancer"
+        k3d cluster create "$cluster_name" -p "8010-8011:30010-30011@loadbalancer" --image rancher/k3s:latest
     fi
 }
 


### PR DESCRIPTION
What does this PR do?
---

Force k3d to use the latest version of k3s so that we also get the latest version of k8s.

This is necessary because Gateway API [only supports the 5 latest versions of k8s](https://gateway-api.sigs.k8s.io/concepts/versioning/#supported-versions) but the latest version of k3d installs with k8s `1.21.7` which is currently 12 versions behind the latest k8s.

You can see this with the `k3d version` command -k3s version is `v1.21.7-k3s1` despite being on the latest k3d, `v5.8.3`, and that k3s version comes with k8s `v1.21.7` as shown [in k3d's release notes](https://github.com/k3s-io/k3s/releases/tag/v1.21.7%2Bk3s1):
![image](https://github.com/user-attachments/assets/0d8541e2-e699-40ce-907d-ead944fee9a4)


This causes the following error when running `./deploy/wineinfo.sh` because Gateway API is not compatible with k8s `1.21.7`:
```sh
error: error validating "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/experimental-install.yaml": error validating data: ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.sessionPersistence): unknown field "x-kubernetes-validations" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps; if you choose to ignore these errors, turn validation off with --validate=false
```
![image](https://github.com/user-attachments/assets/4fd294db-94de-4a44-a31b-eab7ee92bfc2)

If we force k3d to use the latest version of k3s, then we also get the latest version of k8s, and then `./deploy/wineinfo.sh` finishes successfully.
