### PR TITLE
Run WineInfo demo as a presentation

### DIFF
--- a/demo/deploy/02_routing.yaml
+++ b/demo/deploy/02_routing.yaml
@@ -21,7 +21,7 @@ spec:
       - name: main
         image: wineinfo-python:latest
         imagePullPolicy: IfNotPresent
-        command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "8000"]
+        command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "80"]
         envFrom:
         - configMapRef:
             name: wineinfo-config
@@ -51,7 +51,7 @@ spec:
       - name: main
         image: wineinfo-python:latest
         imagePullPolicy: IfNotPresent
-        command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "8000"]
+        command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "80"]
         envFrom:
         - configMapRef:
             name: wineinfo-config
@@ -67,4 +67,3 @@ spec:
     service: catalog-next
   ports:
     - port: 80
-      targetPort: 8000

--- a/demo/deploy/03_retries.yaml
+++ b/demo/deploy/03_retries.yaml
@@ -21,7 +21,7 @@ spec:
       - name: main
         image: wineinfo-python:latest
         imagePullPolicy: IfNotPresent
-        command: ["fastapi", "run", "/app/search_app.py", "--host", "0.0.0.0", "--port", "8000"]
+        command: ["fastapi", "run", "/app/search_app.py", "--host", "0.0.0.0", "--port", "80"]
         envFrom:
         - configMapRef:
             name: wineinfo-config

--- a/demo/deploy/04_ring_hash.yaml
+++ b/demo/deploy/04_ring_hash.yaml
@@ -21,7 +21,7 @@ spec:
       - name: main
         image: wineinfo-python:latest
         imagePullPolicy: IfNotPresent
-        command: ["fastapi", "run", "/app/recs_app.py", "--host", "0.0.0.0", "--port", "8000"]
+        command: ["fastapi", "run", "/app/recs_app.py", "--host", "0.0.0.0", "--port", "80"]
         envFrom:
         - configMapRef:
             name: wineinfo-config

--- a/demo/deploy/05_argo_rollouts_catalog_migrate.yaml
+++ b/demo/deploy/05_argo_rollouts_catalog_migrate.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 8000
   selector:
     app: wineinfo
     service: catalog
@@ -71,7 +70,7 @@ spec:
       - name: main
         image: wineinfo-python:latest
         imagePullPolicy: IfNotPresent
-        command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "8000"]
+        command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "80"]
         envFrom:
         - configMapRef:
             name: wineinfo-config

--- a/demo/deploy/05_argo_rollouts_catalog_policy.yaml
+++ b/demo/deploy/05_argo_rollouts_catalog_policy.yaml
@@ -58,7 +58,7 @@ spec:
               "--host",
               "0.0.0.0",
               "--port",
-              "8000",
+              "80",
             ]
           envFrom:
             - configMapRef:

--- a/demo/live-demo-script.md
+++ b/demo/live-demo-script.md
@@ -259,12 +259,12 @@ Features:
 
 Steps:
 
-11. Simulate Recommendations service load failure `kubectl apply -f demo/deploy/04_ring_hash.yaml` 
+11. Simulate Recommendations service load failure: `kubectl apply -f demo/deploy/04_ring_hash.yaml` 
     > For demo purposes this just sets the `RECS_DEMO_FAILURE` env var to `true` for the wineinfo-recs deployment
 12. Show the failures by making repeated request to the recommendation server with distinct queries (5 reqs in two seconds or more)
     1. Also show failures with the Load Testing widget in recommendations tab by logging in as admin user
-14. Upscale recommendation service `kubectl scale --replicas=4 deployment/wineinfo-recs`
-15. Show problem still exists using Load Testing functionality in recommendations UI in Wineinfo
+14. Upscale recommendation service: `kubectl scale --replicas=4 deployment/wineinfo-recs`
+15. Show problem has gotten better, but still exists using Load Testing functionality in recommendations UI in Wineinfo
 16. Add a load balancing policy to the wineinfo-recs service via the Junction UI
     <details>
       <summary>Service JSON</summary>

--- a/demo/live-demo-script.md
+++ b/demo/live-demo-script.md
@@ -1,11 +1,5 @@
 # WineInfo Demo Script
 
-This script assumes a you are running the demo against a Junction Control Plane (JCP) running natively on your host machine and that WineInfo is running in an [orbstack k8s cluster](https://docs.orbstack.dev/kubernetes/) on the same host machine.
-
-Before starting please make the following modifications in [wineinfo.yaml](../deploy/wineinfo.yaml):
-1. Change the `JUNCTION_ADS_SERVER` variable to `grpc://host.docker.internal:8008`.
-2. And change `NEXTAUTH_URL` to `"http://localhost:30010"`.
-
 ## Routing/traffic splitting
 
 Features:

--- a/demo/live-demo-script.md
+++ b/demo/live-demo-script.md
@@ -1,5 +1,11 @@
 # WineInfo Demo Script
 
+This script assumes a you are running the demo against a Junction Control Plane (JCP) running natively on your host machine and that WineInfo is running in an [orbstack k8s cluster](https://docs.orbstack.dev/kubernetes/) on the same host machine.
+
+Before starting please make the following modifications in [wineinfo.yaml](../deploy/wineinfo.yaml):
+1. Change the `JUNCTION_ADS_SERVER` variable to `grpc://host.docker.internal:8008`.
+2. And change `NEXTAUTH_URL` to `"http://localhost:30010"`.
+
 ## Routing/traffic splitting
 
 Features:

--- a/demo/live-demo-script.md
+++ b/demo/live-demo-script.md
@@ -1,0 +1,283 @@
+# WineInfo Demo Script
+
+## Routing/traffic splitting
+
+Features:
+* Testing in production
+* Feature flagging @ network level
+
+1. Deploy WineInfo: `kubectl apply -f deploy/wineinfo.yaml`
+2. Deploy new catalog service with bug via kubectl
+   > For demo purposes this just sets the `CATALOG_DEMO_MOJIBAKE` env var to `true` for wineinfo-catalog deployment
+    <details>
+      <summary>New catalog deployment yaml</summary>
+
+      ```yml
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: wineinfo-catalog
+        labels:
+          app: wineinfo
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: wineinfo
+            service: catalog
+        template:
+          metadata:
+            labels:
+              app: wineinfo
+              service: catalog
+          spec:
+            containers:
+            - name: main
+              image: wineinfo-python:latest
+              imagePullPolicy: IfNotPresent
+              command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "80"]
+              envFrom:
+              - configMapRef:
+                  name: wineinfo-config
+              env:
+              - name: CATALOG_DEMO_MOJIBAKE
+                value: "true"
+        ```
+    </details>
+3. Show encoding bug in WineInfo UI
+4. Deploy new catalog service with bug fix via kubectl
+    <detials>
+      <summary>Catalog next deployment yaml</summary>
+
+      ```yml
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: wineinfo-catalog-next
+        labels:
+          app: wineinfo
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: wineinfo
+            service: catalog-next
+        template:
+          metadata:
+            labels:
+              app: wineinfo
+              service: catalog-next
+          spec:
+            containers:
+            - name: main
+              image: wineinfo-python:latest
+              imagePullPolicy: IfNotPresent
+              command: ["fastapi", "run", "/app/catalog_app.py", "--host", "0.0.0.0", "--port", "80"]
+              envFrom:
+              - configMapRef:
+                  name: wineinfo-config
+      ---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: wineinfo-catalog-next
+      spec:
+        type: ClusterIP
+        selector:
+          app: wineinfo
+          service: catalog-next
+        ports:
+          - port: 80
+      ```
+    </detials>
+5. Create route in Junction UI
+   <details>
+    <summary>Route JSON</summary>
+    
+    ```json
+    {
+      "id": "wineinfo-catalog",
+      "tags": {},
+      "hostnames": [
+        "wineinfo-catalog.default.svc.cluster.local"
+      ],
+      "ports": [],
+      "rules": [
+        {
+          "matches": [
+            {
+              "headers": [
+                {
+                  "type": "RegularExpression",
+                  "name": "baggage",
+                  "value": ".*username=admin(,|$).*"
+                }
+              ]
+            }
+          ],
+          "backends": [
+            {
+              "type": "kube",
+              "name": "wineinfo-catalog-next",
+              "namespace": "default",
+              "port": 80,
+              "weight": 1
+            }
+          ]
+        },
+        {
+          "backends": [
+            {
+              "type": "kube",
+              "name": "wineinfo-catalog",
+              "namespace": "default",
+              "port": 80,
+              "weight": 1
+            }
+          ]
+        }
+      ]
+    }
+    ```
+   </details>
+6. Test fix in production by logging in as admin user
+
+## Advanced routing functionality
+
+Features:
+* Timeouts
+* Retries
+
+7. Simulate latency spikes in search: `kubectl apply -f demo/deploy/03_retries.yaml` 
+   > For demo purposes this just sets the `SEARCH_DEMO_LATENCY` env var to `true` for wineinfo-search deployment
+8. Show latency issues in WineInof UI
+9. Create route in Junction UI with timeouts and automatic retries
+  a. Show that we could also make the default route have timeouts and automatic retries, instead of using a path match
+  <details>
+    <summary>Route JSON</summary>
+
+    ```json
+    {
+      "id": "wineinfo-search",
+      "tags": {},
+      "hostnames": [
+        "wineinfo-search.default.svc.cluster.local"
+      ],
+      "ports": [],
+      "rules": [
+        {
+          "matches": [
+            {
+              "path": {
+                "type": "Exact",
+                "value": "/search/"
+              }
+            }
+          ],
+          "timeouts": {
+            "backend_request": 0.1
+          },
+          "retry": {
+            "attempts": 5,
+            "backoff": 0.1
+          },
+          "backends": [
+            {
+              "type": "kube",
+              "name": "wineinfo-search",
+              "namespace": "default",
+              "port": 80,
+              "weight": 1
+            }
+          ]
+        },
+        {
+          "backends": [
+            {
+              "type": "kube",
+              "name": "wineinfo-search",
+              "namespace": "default",
+              "port": 80,
+              "weight": 1
+            }
+          ]
+        }
+      ]
+    }
+    ```
+  
+    With just the default route:
+    ```json
+    {
+      "id": "wineinfo-search",
+      "tags": {},
+      "hostnames": [
+        "wineinfo-search.default.svc.cluster.local"
+      ],
+      "ports": [],
+      "rules": [
+        {
+          "timeouts": {
+            "backend_request": 0.1
+          },
+          "retry": {
+            "attempts": 5,
+            "backoff": 0.1
+          },
+          "backends": [
+            {
+              "type": "kube",
+              "name": "wineinfo-search",
+              "namespace": "default",
+              "port": 80,
+              "weight": 1
+            }
+          ]
+        }
+      ]
+    }
+    ```
+  </details>
+10. Test fix by running a bunch of searches and seeing latency is decreased
+
+## Load Balancing
+
+Features:
+* Client-side load balancing
+
+11. Simulate Recommendations service load failure `kubectl apply -f demo/deploy/04_ring_hash.yaml` 
+    > For demo purposes this just sets the `RECS_DEMO_FAILURE` env var to `true` for the wineinfo-recs deployment
+12. Show the failures by making repeated request to the recommendation server with distinct queries (5 reqs in two seconds or more)
+  a. Also show failures with the Load Testing widget in recommendations tab by logging in as admin user
+13. Upscale recommendation service `kubectl scale --replicas=4 deployment/wineinfo-recs`
+14. Show problem still exists using Load Testing functionality in recommendations UI in Wineinfo
+15. Add a load balancing policy to the wineinfo-recs service via the Junction UI
+    <details>
+      <summary>Service JSON</summary>
+
+      ```json
+      {
+        "id": {
+          "type": "kube",
+          "name": "wineinfo-recs",
+          "namespace": "default"
+        },
+        "backends": [
+          {
+            "port": 80,
+            "lb": {
+              "type": "RingHash",
+              "min_ring_size": 1024,
+              "hash_params": [
+                {
+                  "type": "QueryParam",
+                  "name": "query"
+                }
+              ]
+            }
+          }
+        ]
+      }
+      ```
+    </details>
+16. Run a load test in the recommendations UI in Wineinfo again to show ring hash is working

--- a/deploy/wineinfo.yaml
+++ b/deploy/wineinfo.yaml
@@ -5,13 +5,13 @@ metadata:
   name: wineinfo-config
 data:
   DATA_PATH: /app/data/gen
-  JUNCTION_ADS_SERVER: grpc://host.docker.internal:8008
+  JUNCTION_ADS_SERVER: grpc://ezbake.junction:8008
   USE_JUNCTION: "true"
   CATALOG_SERVICE: "http://wineinfo-catalog"
   SEARCH_SERVICE: "http://wineinfo-search"
   RECS_SERVICE: "http://wineinfo-recs"
   PERSIST_SERVICE: "http://wineinfo-persist"
-  NEXTAUTH_URL: "http://localhost:30010"
+  NEXTAUTH_URL: "http://localhost:8010"
   COLUMNS: "9999" # Helps FastAPI logs not wrap lines
 ---
 apiVersion: apps/v1

--- a/deploy/wineinfo.yaml
+++ b/deploy/wineinfo.yaml
@@ -52,7 +52,6 @@ spec:
   ports:
     - nodePort: 30010
       port: 3000
-      targetPort: 3000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -84,7 +83,7 @@ spec:
               "--host",
               "0.0.0.0",
               "--port",
-              "8000",
+              "80",
             ]
           envFrom:
             - configMapRef:
@@ -101,7 +100,6 @@ spec:
     service: catalog
   ports:
     - port: 80
-      targetPort: 8000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -133,7 +131,7 @@ spec:
               "--host",
               "0.0.0.0",
               "--port",
-              "8000",
+              "80",
             ]
           envFrom:
             - configMapRef:
@@ -150,7 +148,6 @@ spec:
     service: persist
   ports:
     - port: 80
-      targetPort: 8000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -182,7 +179,7 @@ spec:
               "--host",
               "0.0.0.0",
               "--port",
-              "8000",
+              "80",
             ]
           envFrom:
             - configMapRef:
@@ -199,7 +196,6 @@ spec:
     service: recs
   ports:
     - port: 80
-      targetPort: 8000
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -231,7 +227,7 @@ spec:
               "--host",
               "0.0.0.0",
               "--port",
-              "8000",
+              "80",
             ]
           envFrom:
             - configMapRef:
@@ -248,4 +244,3 @@ spec:
     service: search
   ports:
     - port: 80
-      targetPort: 8000

--- a/deploy/wineinfo.yaml
+++ b/deploy/wineinfo.yaml
@@ -12,6 +12,7 @@ data:
   RECS_SERVICE: "http://wineinfo-recs"
   PERSIST_SERVICE: "http://wineinfo-persist"
   NEXTAUTH_URL: "http://localhost:30010"
+  COLUMNS: "9999" # Helps FastAPI logs not wrap lines
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/wineinfo.yaml
+++ b/deploy/wineinfo.yaml
@@ -5,13 +5,13 @@ metadata:
   name: wineinfo-config
 data:
   DATA_PATH: /app/data/gen
-  JUNCTION_ADS_SERVER: grpc://ezbake.junction:8008
+  JUNCTION_ADS_SERVER: grpc://host.docker.internal:8008
   USE_JUNCTION: "true"
   CATALOG_SERVICE: "http://wineinfo-catalog"
   SEARCH_SERVICE: "http://wineinfo-search"
   RECS_SERVICE: "http://wineinfo-recs"
   PERSIST_SERVICE: "http://wineinfo-persist"
-  NEXTAUTH_URL: "http://localhost:8010"
+  NEXTAUTH_URL: "http://localhost:30010"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/frontend/src/app/api/wine/recs/route.ts
+++ b/frontend/src/app/api/wine/recs/route.ts
@@ -28,10 +28,12 @@ export async function GET(request: NextRequest) {
             [];
 
         return NextResponse.json(wines);
-    } catch (error) {
+    } catch (error: any) {
+        const status = error.status || 500;
+        const message = error.message || "Failed to get recommendations";
         return NextResponse.json(
-            { error: "Failed to get recommendations" },
-            { status: 500 }
+            { error: message },
+            { status }
         );
     }
 }

--- a/frontend/src/components/WineCatalog.tsx
+++ b/frontend/src/components/WineCatalog.tsx
@@ -50,7 +50,7 @@ function SearchInput({
 
     return (
         <div className="flex gap-2 mb-4">
-            <InputComponent
+            <Input
                 placeholder={placeholder}
                 value={value}
                 onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(e.target.value)}
@@ -150,7 +150,7 @@ export default function WineCatalog({ isLoggedIn }: WineCatalogProps) {
                 totalPages = data.total_pages;
                 total = data.total;
             } else if (activeTab === 'recommendations') {
-                wineData = await recommendWines(searchTerm);
+                wineData = await recommendWines(searchTerm.trim());
                 totalPages = 1;
                 total = wineData.length;
             } else {

--- a/frontend/src/lib/server/httpClient.ts
+++ b/frontend/src/lib/server/httpClient.ts
@@ -1,102 +1,118 @@
-import type { Session } from 'next-auth'
+import type { Session } from "next-auth";
 
 export interface Fetcher {
-    fetch(url: string, config: RequestInit): Promise<Response>;
+	fetch(url: string, config: RequestInit): Promise<Response>;
 }
 
 export interface HttpClientOptions {
-    additionalHeaders: Headers;
-    baggage: Record<string, string>;
+	additionalHeaders: Headers;
+	baggage: Record<string, string>;
 }
 
 export function emptyOptions(): HttpClientOptions {
-    return {
-        additionalHeaders: new Headers(),
-        baggage: {}
-    }
+	return {
+		additionalHeaders: new Headers(),
+		baggage: {},
+	};
 }
 
-export function sessionOptions(incomingHeaders: Headers, session: Session | null): HttpClientOptions {
-    const requestId = incomingHeaders.get('x-request-id') || crypto.randomUUID()
-    return {
-        additionalHeaders: new Headers(),
-        baggage: {
-            'request-id': requestId,
-            'user-id': session?.user?.id || '',
-            'username': session?.user?.name || ''
-        }
-    }
+export function sessionOptions(
+	incomingHeaders: Headers,
+	session: Session | null,
+): HttpClientOptions {
+	const requestId = incomingHeaders.get("x-request-id") || crypto.randomUUID();
+	return {
+		additionalHeaders: new Headers(),
+		baggage: {
+			"request-id": requestId,
+			"user-id": session?.user?.id || "",
+			username: session?.user?.name || "",
+		},
+	};
 }
 
 export class HttpClient {
-    private junction: any;
+	private junction: any;
 
-    constructor(private baseUrl: string, useJunction: boolean) {
-        this.baseUrl = baseUrl.replace(/\/$/, '');
-        if (useJunction) {
-            this.junction = require("@junction-labs/client");
-        }
-    }
+	constructor(
+		private baseUrl: string,
+		useJunction: boolean,
+	) {
+		this.baseUrl = baseUrl.replace(/\/$/, "");
+		if (useJunction) {
+			this.junction = require("@junction-labs/client");
+		}
+	}
 
-    private async fetch(input: string | URL | globalThis.Request, init?: RequestInit): Promise<Response> {
-        if (this.junction) {
-            return this.junction.fetch(input, init);
-        } else {
-            return fetch(input, init);
-        }
-    }
+	private async fetch(
+		input: string | URL | globalThis.Request,
+		init?: RequestInit,
+	): Promise<Response> {
+		if (this.junction) {
+			return this.junction.fetch(input, init);
+		} else {
+			return fetch(input, init);
+		}
+	}
 
-    private async request<T>(
-        method: 'GET' | 'POST',
-        path: string,
-        data?: any,
-        options: HttpClientOptions = emptyOptions()
-    ): Promise<T> {
-        try {
-            const headers: Headers = new Headers(options.additionalHeaders);
-            if (method === 'POST' && !headers.has('Content-Type')) {
-                headers.set('Content-Type', 'application/json');
-            }
-            headers.set('baggage', Object.entries(options.baggage)
-                .map(([key, value]) => `${key}=${value}`)
-                .join(','))
-            const request: RequestInit = { method, headers };
+	private async request<T>(
+		method: "GET" | "POST",
+		path: string,
+		data?: any,
+		options: HttpClientOptions = emptyOptions(),
+	): Promise<T> {
+		const headers: Headers = new Headers(options.additionalHeaders);
+		if (method === "POST" && !headers.has("Content-Type")) {
+			headers.set("Content-Type", "application/json");
+		}
+		headers.set(
+			"baggage",
+			Object.entries(options.baggage)
+				.map(([key, value]) => `${key}=${value}`)
+				.join(","),
+		);
+		const request: RequestInit = { method, headers };
 
-            if (method === 'GET' && data) {
-                const params = new URLSearchParams();
-                Object.entries(data).forEach(([key, value]) => {
-                    if (Array.isArray(value)) {
-                        value.forEach(v => params.append(key, v.toString()));
-                    } else if (value !== undefined && value !== null) {
-                        params.append(key, value.toString());
-                    }
-                });
-                path = `${path}?${params.toString()}`;
-            } else if (data) {
-                request.body = JSON.stringify(data);
-            }
+		if (method === "GET" && data) {
+			const params = new URLSearchParams();
+			Object.entries(data).forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					value.forEach((v) => params.append(key, v.toString()));
+				} else if (value !== undefined && value !== null) {
+					params.append(key, value.toString());
+				}
+			});
+			path = `${path}?${params.toString()}`;
+		} else if (data) {
+			request.body = JSON.stringify(data);
+		}
 
-            const response = await this.fetch(`${this.baseUrl}${path}`, request);
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            return response.json();
-        } catch (error) {
-            throw new Error(`Request failed: ${error}`);
-        }
-    }
+		const response = await this.fetch(`${this.baseUrl}${path}`, request);
+		if (!response.ok) {
+			const errorText = await response.text();
+			const error = new Error(
+				errorText || `HTTP ${response.status}: ${response.statusText}`,
+			);
+			(error as any).status = response.status;
+			(error as any).statusText = response.statusText;
+			throw error;
+		}
+		return response.json();
+	}
 
-    async get<T>(
-        path: string,
-        data?: any,
-        options: HttpClientOptions = emptyOptions()): Promise<T> {
-        return this.request<T>('GET', path, data, options);
-    }
+	async get<T>(
+		path: string,
+		data?: any,
+		options: HttpClientOptions = emptyOptions(),
+	): Promise<T> {
+		return this.request<T>("GET", path, data, options);
+	}
 
-    async post<T>(
-        path: string,
-        data: any,
-        options: HttpClientOptions = emptyOptions()): Promise<T> {
-        return this.request<T>('POST', path, data, options);
-    }
+	async post<T>(
+		path: string,
+		data: any,
+		options: HttpClientOptions = emptyOptions(),
+	): Promise<T> {
+		return this.request<T>("POST", path, data, options);
+	}
 }


### PR DESCRIPTION
What does this PR do?
---

This PR does two separate but related things:
* Removes the `80:8000` port mappings for the WineInfo services for now and serves them on port `80`.
* Adds a script for running through the demo as a presentation alongside changes to make it easier to present different parts of the demo, such as better error messaging in the WineInfo UI, and a load testing widget so the load balancing portion of the demo can be shown via the WineInfo UI, as opposed to having to setup a python virtual environment to run a script in the terminal.
<details>
  <summary>Load Balancing Widget Screen Recording</summary>
  
  https://github.com/user-attachments/assets/89b80248-a1ab-47ac-abf6-70946c4dc9f3
</details>